### PR TITLE
Postman Challenge PR merged, but Points not added

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,5 +84,6 @@ git push origin <your-branch-name>
 9. **Wait for Review:**
     Your pull request will now be available for review by the project maintainers. They may provide feedback or ask for changes before merging your pull request into the main branch of the machine-learning-repos repository.
 
+
 ⭐️ Support the Project
 If you find this project helpful, please consider giving it a star on GitHub! Your support helps to grow the project and reach more contributors.


### PR DESCRIPTION
## Description
My PR related to Postman challenge got accepted, but the points and badge is not yet added to the leaderboard. 
PR Link: https://github.com/GSSoC24/Postman-Challenge/pull/452

Fixes #

## Type of change

- [ ] Added a new machine learning frameworks, libraries or software.
- [x] Documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
