### PR TITLE
Add server listen functionality to start Express server

### DIFF
--- a/Website/server/server.js
+++ b/Website/server/server.js
@@ -3,7 +3,7 @@ import fetch from "node-fetch";
 import path from "path";
 import { fileURLToPath } from "url";
 import dotenv from "dotenv";
-import router from "./route.js";
+import router from "./route.js"; // Make sure this file exists
 
 dotenv.config();
 
@@ -11,65 +11,71 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const app = express();
+const PORT = process.env.PORT || 3000; // Set PORT
 
 app.use(express.static(path.join(__dirname, "../")));
 
 app.get("/api/github/repos/subdir", async (req, res) => {
-  const dirName = req.query.dir;
-  if (!dirName) {
-    return res.status(400).json({ error: "Directory name is required" });
-  }
-
-  try {
-    const response = await fetch(
-      `https://api.github.com/repos/recodehive/machine-learning-repos/contents/${dirName}`,
-      {
-        headers: {
-          Authorization: `Bearer ${GITHUB_TOKEN}`,
-        },
-      }
-    );
-    if (!response.ok) {
-      const errorDetails = await response.text();
-      throw new Error(
-        `GitHub API error: ${response.status} - ${response.statusText}: ${errorDetails}`
-      );
+    const dirName = req.query.dir;
+    if (!dirName) {
+        return res.status(400).json({ error: "Directory name is required" });
     }
 
-    const data = await response.json();
-    res.json(data);
-  } catch (error) {
-    console.error(
-      `Error fetching GitHub subdirectory contents for ${dirName}:`,
-      error
-    );
-    res.status(500).json({ error: error.message });
-  }
+    try {
+        const response = await fetch(
+            `https://api.github.com/repos/recodehive/machine-learning-repos/contents/${dirName}`,
+            {
+                headers: {
+                    Authorization: `Bearer ${GITHUB_TOKEN}`,
+                },
+            }
+        );
+        if (!response.ok) {
+            const errorDetails = await response.text();
+            throw new Error(
+                `GitHub API error: ${response.status} - ${response.statusText}: ${errorDetails}`
+            );
+        }
+
+        const data = await response.json();
+        res.json(data);
+    } catch (error) {
+        console.error(
+            `Error fetching GitHub subdirectory contents for ${dirName}:`,
+            error
+        );
+        res.status(500).json({ error: error.message });
+    }
 });
 
 app.get("/api/github/repos", async (req, res) => {
-  try {
-    const response = await fetch(
-      "https://api.github.com/repos/recodehive/machine-learning-repos/contents/",
-      {
-        headers: {
-          Authorization: `Bearer ${GITHUB_TOKEN}`,
-        },
-      }
-    );
-    if (!response.ok) {
-      const errorDetails = await response.text();
-      throw new Error(
-        `GitHub API error: ${response.status} - ${response.statusText}: ${errorDetails}`
-      );
-    }
+    try {
+        const response = await fetch(
+            "https://api.github.com/repos/recodehive/machine-learning-repos/contents/",
+            {
+                headers: {
+                    Authorization: `Bearer ${GITHUB_TOKEN}`,
+                },
+            }
+        );
+        if (!response.ok) {
+            const errorDetails = await response.text();
+            throw new Error(
+                `GitHub API error: ${response.status} - ${response.statusText}: ${errorDetails}`
+            );
+        }
 
-    const data = await response.json();
-    res.json(data);
-  } catch (error) {
-    console.error("Error fetching GitHub directories:", error);
-    res.status(500).json({ error: error.message });
-  }
+        const data = await response.json();
+        res.json(data);
+    } catch (error) {
+        console.error("Error fetching GitHub directories:", error);
+        res.status(500).json({ error: error.message });
+    }
+});
+
+// Start the server
+app.listen(PORT, () => {
+    console.log(`Server is running on http://localhost:${PORT}`);
 });
 
 export default app;


### PR DESCRIPTION
## Description

- Added server listening functionality to start the Express server, allowing it to run on the specified port. This enables the server to handle incoming requests and serve static files.

- Previously, the code did not include a listen function for starting the server. Without this functionality, the server could not handle requests, making the API endpoints inaccessible. This update resolves that issue.

- No new dependencies were added for this change.

Fixes # 1443

## Type of change
Added server listening functionality


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
