### PR TITLE
The Items of the legend are out of the box container (Fixes: #1620)

### DIFF
--- a/Website/css/styles.css
+++ b/Website/css/styles.css
@@ -475,7 +475,7 @@ div {
     background-color: #121245;
     padding: 10px 20px;
     border-radius: 15px;
-    height: 340px;
+    height: 450px;
     color: white;
     animation: slideInRight 0.3s ease-in-out;
     transition: background-color 0.3s ease;
@@ -553,7 +553,7 @@ div {
     background-color: #121245;
     padding: 10px 20px;
     border-radius: 15px;
-    height: 340px;
+    height: 450px;
     color: white;
     animation: slideInRight 1s ease-in-out;
     transition: background-color 0.3s ease;


### PR DESCRIPTION

## Description

The Items of the legend are out of the box container. Fixed this by increasing the height of the containers

Fixes #1620

## Type of change

- [ X] Added a new machine learning frameworks, libraries or software.
- [ ] Documentation update

## Checklist:

- [X ] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have made corresponding changes to the documentation
- [ X] My changes generate no new warnings
