### PR TITLE
Updated ISSUE_TEMPLATE labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -37,10 +37,12 @@ body:
       label: What browsers are you seeing the problem on?
       multiple: true
       options:
+        - All (its generally a browser agnostic issue)
         - Firefox
         - Chrome
         - Safari
         - Microsoft Edge
+        - Other
   - type: checkboxes
     id: terms
     attributes:
@@ -48,7 +50,9 @@ body:
       options:
         - label: "I have read the Contributing Guidelines"
           required: true
-        - label: "I'm a GSSOC'24 contributor"
+        - label: "I'm a GSSOC'25 contributor"
+          required: false
+        - label: "I'm a Hacktoberfest contributor"
           required: false
         - label: "I want to work on this issue"
           required: false

--- a/.github/ISSUE_TEMPLATE/documentation_update.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_update.yml
@@ -54,7 +54,9 @@ body:
       options:
         - label: "I have read the Contributing Guidelines"
           required: true
-        - label: "I'm a GSSOC'24 contributor"
+        - label: "I'm a GSSOC'25 contributor"
+          required: false
+        - label: "I'm a Hacktoberfest contributor"
           required: false
         - label: "I want to work on this issue"
           required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -57,7 +57,9 @@ body:
       options:
         - label: "I have read the Contributing Guidelines"
           required: true
-        - label: "I'm a GSSOC'24 contributor"
+        - label: "I'm a GSSOC'25 contributor"
+          required: false
+        - label: "I'm a Hacktoberfest contributor"
           required: false
         - label: "I want to work on this issue"
           required: false


### PR DESCRIPTION
## Description

- Removed the outdated `GSSoC'24 contributor` label from all templates.

- Added the `GSSoC'25 contributor` label to all templates.

- Added the `hacktoberfest contributor` label to all templates.

Fixes #1674 

## Type of change

- [ ] Added a new machine learning frameworks, libraries or software.
- [ ] Documentation update
- [x] `.github/ISSUE_TEMPLATE` update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
