### PR TITLE
docs: Fix typo in README - change 'exprience' to 'experience'

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,7 +879,7 @@ Through these stages, the machine learning workflow provides a systematic approa
 <details>
  <summary><h2 id="projects">🔰Projects</h2>  
 
-> These Projects help you gain real time exprience for building Machine Learning models.
+> These Projects help you gain real time experience for building Machine Learning models.
 </summary>
 
   <table width="100%">


### PR DESCRIPTION
## Description
Fixed a typo in the README file where 'exprience' was incorrectly spelled. Changed it to 'experience'.

## Type of Change
- [x] Documentation update